### PR TITLE
fix(rust): rust analyzer fails because of unstable flag '--keep-going'

### DIFF
--- a/rust/idx-template.nix
+++ b/rust/idx-template.nix
@@ -6,6 +6,8 @@
     mkdir -p app/.idx
     cp ${./dev.nix} app/.idx/dev.nix
     chmod +w app/.idx/dev.nix
+    mkdir -p app/.vscode
+    printf "{\n    \"rust-analyzer.cargo.extraArgs\": [\"-Z\", \"unstable-options\"]\n}" > app/.vscode/settings.json
     mv app "$out"
   '';
 }


### PR DESCRIPTION
Current rust template uses stable-23.11 channel which has cargo 1.73.0, when the VSCode Rust Analyzer runs, it will check against `--keep-going` flag with the following error message

```
error: the `--keep-going` flag is unstable, pass `-Z unstable-options` to enable it
See https://github.com/rust-lang/cargo/issues/10496 for more information about the `--keep-going` flag.
```

To fix this error, we should add the `-Z unstable-options` flag in the cargo check command which Rust Analyzer runs on.