### PR TITLE
Copy views directory to dist as part of build step

### DIFF
--- a/node-express/web-ts/package.json
+++ b/node-express/web-ts/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "nodemon --watch --ext 'ts,json' --exec 'npm run build && npm run start'",
-    "build": "tsc",
+    "build": "tsc && cp -r views dist",
     "start": "node dist/index.js"
   },
   "keywords": [],


### PR DESCRIPTION
Without this change, the `dist` build directory doesn't contain `views` directory on build. The user gets the following error:

```
Error: Failed to lookup view "index" in views directory "/home/user/{appname}/dist/views"
    at Function.render (/home/user/{appname}/node_modules/express/lib/application.js:597:17)
    ...
```

