### PR TITLE
feat: add preset connection to the MongoDB VS Code extension

### DIFF
--- a/mongodb/blank/.vscode/settings.json
+++ b/mongodb/blank/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "mdb.presetConnections": [
+        {
+            "name": "Local Database",
+            "connectionString": "mongodb://localhost:27017"
+        }
+    ]
+}

--- a/mongodb/express/.vscode/settings.json
+++ b/mongodb/express/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "mdb.presetConnections": [
+        {
+            "name": "Local Database",
+            "connectionString": "mongodb://localhost:27017"
+        }
+    ]
+}

--- a/mongodb/flask/.vscode/settings.json
+++ b/mongodb/flask/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "mdb.presetConnections": [
+        {
+            "name": "Local Database",
+            "connectionString": "mongodb://localhost:27017"
+        }
+    ]
+}


### PR DESCRIPTION
This pull request adds a VS Code configuration for a preset connection to the MongoDB extension within the MongoDB template.
When a user creates a workspace using this template, they automatically get a preset connection to their local MongoDB instance, simplifying the setup process.